### PR TITLE
fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # These are the reqs to build docs and run tests.
 sphinx
 -e git://github.com/jbalogh/django-nose.git@6f060d49ee193a05734704820f3fea92ee1759d2#egg=django-nose
--e svn+http://code.djangoproject.com/svn/django/trunk#egg=Django
+django==1.8.12
 fabric

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 
 
 setup(
-    name='test-utils',
-    version='0.3',
+    name='krux-test-utils',
+    version='0.3.1',
     description='Grab bag of test utilities for Django & Jinja2 & Selenium.',
     long_description=open('README.rst').read(),
     author='Jeff Balogh',


### PR DESCRIPTION
To install from pip without git, we'll need our own name and version number. This is required to get rb_dataconsole tests running under docker.
